### PR TITLE
Allow the code to run on followers

### DIFF
--- a/lib/zelastic/indexer.rb
+++ b/lib/zelastic/indexer.rb
@@ -72,7 +72,9 @@ module Zelastic
     def_delegators :config, :logger
 
     def current_version
-      config.data_source.connection.select_one('SELECT txid_current()').fetch('txid_current')
+      config.data_source.connection
+            .select_one('SELECT select txid_snapshot_xmax(txid_current_snapshot()) as xmax')
+            .fetch('xmax')
     end
 
     def write_indices(client)


### PR DESCRIPTION
From the documentaiton txid_current():
get current transaction ID, assigning a new one if the current
transaction does not have one.

This prevents us to use txid_current() on the follower.
Getting txid_current_snapshot allows us to get the xmax value from the
current snapshot, and the code will run on both the master and the
follower.