### PR TITLE
Log reindexing with a progress bar, showing % completion and ETA

### DIFF
--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -27,7 +27,12 @@ module Zelastic
                      config.write_alias
                    end
 
+      total = config.data_source.count
+      indexed_count = 0
+
       config.data_source.find_in_batches(batch_size: batch_size) do |batch|
+        indexed_count += batch_size
+        logger.info("ES: (#{(indexed_count.to_f/total * 100).round(2)}% - #{indexed_count}/#{total}) Indexing #{config.type} records")
         indexer.index_batch(batch, client: client, index_name: index_name)
       end
     end

--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -27,12 +27,12 @@ module Zelastic
                      config.write_alias
                    end
 
-      total = config.data_source.count
       indexed_count = 0
 
       config.data_source.find_in_batches(batch_size: batch_size) do |batch|
         indexed_count += batch_size
-        logger.info("ES: (#{(indexed_count.to_f/total * 100).round(2)}% - #{indexed_count}/#{total}) Indexing #{config.type} records")
+        indexed_percent = (indexed_count.to_f/current_index_size * 100).round(2)
+        logger.info("ES: (ESTIMATED: #{indexed_percent}%) Indexing #{config.type} records")
         indexer.index_batch(batch, client: client, index_name: index_name)
       end
     end
@@ -110,6 +110,10 @@ module Zelastic
 
     def indexer
       @indexer ||= Indexer.new(config)
+    end
+
+    def current_index_size
+      @current_index_size ||= client.count(index: config.read_alias, type: config.type)['count']
     end
   end
 end

--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -27,12 +27,8 @@ module Zelastic
                      config.write_alias
                    end
 
-      indexed_count = 0
-
-      config.data_source.find_in_batches(batch_size: batch_size) do |batch|
-        indexed_count += batch_size
-        indexed_percent = (indexed_count.to_f/current_index_size * 100).round(2)
-        logger.info("ES: (ESTIMATED: #{indexed_percent}%) Indexing #{config.type} records")
+      config.data_source.find_in_batches(batch_size: batch_size).with_index do |batch, idx|
+        logger.info("ES: (ESTIMATED: #{indexed_percent(batch_size, idx + 1)}%) Indexing #{config.type} records")
         indexer.index_batch(batch, client: client, index_name: index_name)
       end
     end
@@ -114,6 +110,10 @@ module Zelastic
 
     def current_index_size
       @current_index_size ||= client.count(index: config.read_alias, type: config.type)['count']
+    end
+
+    def indexed_percent(batch_size, batch_number)
+      (batch_size * batch_number.to_f / current_index_size * 100).round(2)
     end
   end
 end

--- a/lib/zelastic/indexer.rb
+++ b/lib/zelastic/indexer.rb
@@ -18,12 +18,10 @@ module Zelastic
     end
 
     def index_batch(batch, client: nil, index_name: nil)
-      logger.info("ES: Indexing #{config.type} record")
-
       version = current_version
-      execute_bulk(client: client, index_name: index_name) do |index_name|
+      execute_bulk(client: client, index_name: index_name) do |index|
         batch.map do |record|
-          index_command(index: index_name, version: version, record: record)
+          index_command(index: index, version: version, record: record)
         end
       end
     end


### PR DESCRIPTION
Reindexing can take over half an hour now.

This PR adds an _estimated_ (!!) completion of the reindexing, to at least give some vague indication of the ETA.

Note that it does not use fully accurate numbers, as this could potentially be a big performance issue. Therefore the % may count up to 90% or 110% -- but still, better than nothing! (And it will _usually_ be approximately 100%.)