### PR TITLE
Update for Elasticsearch 7.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ references:
   elasticsearch_container: &elasticsearch_container
     image: carwow/elasticsearch-ci:5.5.1
 
+  elasticsearch_7_container: &elasticsearch_7_container
+    image: cga1123/elasticsearch-ci:7.6.1
+
 version: 2
 jobs:
   bundle:
@@ -54,6 +57,24 @@ jobs:
       - run: |
           bundle exec rspec --pattern "**/*_spec.rb" --format "progress"
 
+  tests_7:
+    working_directory: ~/zelastic
+    docker:
+      - *ruby
+      - *elasticsearch_7_container
+    steps:
+      - checkout
+      - restore_cache: { keys: ['bundle-{{ checksum "Gemfile.lock" }}'] }
+      - run:
+          name: Wait for ES to be ready
+          command: |
+            until curl $ELASTICSEARCH_URL/_cat/health | egrep '(green|yellow)' 2>&1 > /dev/null; do
+              echo -n .
+              sleep 1
+            done
+      - run: |
+          bundle exec rspec --pattern "**/*_spec.rb" --format "progress"
+
 workflows:
   version: 2
   build:
@@ -62,4 +83,6 @@ workflows:
       - rubocop:
           requires: [bundle]
       - tests:
+          requires: [bundle]
+      - tests_7:
           requires: [bundle]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
     image: carwow/elasticsearch-ci:5.5.1
 
   elasticsearch_7_container: &elasticsearch_7_container
-    image: cga1123/elasticsearch-ci:7.6.1
+    image: carwow/elasticsearch-ci:7.6.1
 
 version: 2
 jobs:

--- a/lib/zelastic/config.rb
+++ b/lib/zelastic/config.rb
@@ -15,7 +15,12 @@ module Zelastic
       @data_source = data_source
       @mapping = mapping
       @index_data = index_data
+      @type = overrides.fetch(:type, true)
       @overrides = overrides
+    end
+
+    def type?
+      @type
     end
 
     def index_data(model)
@@ -36,13 +41,14 @@ module Zelastic
 
     def logger
       return Rails.logger if defined?(Rails)
+
       @logger ||= Logger.new(STDOUT)
     end
 
     def index_definition
       {
         settings: overrides.fetch(:index_settings, {}),
-        mappings: { type => mapping }
+        mappings: type ? { type => mapping } : mapping
       }
     end
 

--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module Zelastic
-  class IndexManager
+  # rubocop:disable Metrics/AbcSize
+  class IndexManager # rubocop:disable Metrics/ClassLength
     extend Forwardable
 
     def initialize(config, client: nil)
@@ -25,7 +26,6 @@ module Zelastic
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def switch_read_index(new_name)
       new_index = [config.read_alias, new_name].join('_')
 
@@ -89,7 +89,6 @@ module Zelastic
       )
       client.indices.delete(index: indices_to_delete)
     end
-    # rubocop:enable Metrics/AbcSize
 
     private
 
@@ -118,7 +117,14 @@ module Zelastic
     end
 
     def current_index_size
-      @current_index_size ||= client.count(index: config.read_alias, type: config.type)['count']
+      @current_index_size ||= client.count(**count_params)['count']
+    end
+
+    def count_params
+      {
+        index: config.read_alias,
+        type: config.type? ? config.type : nil
+      }.compact
     end
 
     def indexed_percent(batch_size, batch_number)
@@ -129,4 +135,5 @@ module Zelastic
       client.indices.exists?(index: config.read_alias)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/lib/zelastic/indexer.rb
+++ b/lib/zelastic/indexer.rb
@@ -43,13 +43,10 @@ module Zelastic
 
       execute_bulk do |index_name|
         ids.map do |id|
-          {
-            delete: {
-              _index: index_name,
-              _type: config.type,
-              _id: id
-            }
-          }
+          delete_params = { _index: index_name, _id: id }
+          delete_params[:_type] = config.type if config.type?
+
+          { delete: delete_params }
         end
       end
     end
@@ -78,15 +75,19 @@ module Zelastic
     end
 
     def index_command(index:, version:, record:)
+      version_params =
+        if config.type?
+          { _version: version, _version_type: :external, _type: config.type }
+        else
+          { version: version, version_type: :external }
+        end
+
       {
         index: {
           _index: index,
-          _type: config.type,
           _id: record.id,
-          _version: version,
-          _version_type: :external,
           data: config.index_data(record)
-        }
+        }.merge(version_params)
       }
     end
 
@@ -117,6 +118,7 @@ module Zelastic
       logger.warn("Ignoring #{ignorable_errors.count} version conflicts") if ignorable_errors.any?
 
       return unless important_errors.any?
+
       raise IndexingError, important_errors
     end
 

--- a/lib/zelastic/indexer.rb
+++ b/lib/zelastic/indexer.rb
@@ -124,7 +124,12 @@ module Zelastic
 
     def ignorable_error?(error)
       # rubocop:disable Metrics/LineLength
-      regexp = /^\[#{config.type}\]\[\d+\]: version conflict, current version \[\d+\] is higher or equal to the one provided \[\d+\]$/
+      regexp =
+        if config.type?
+          /^\[#{config.type}\]\[\d+\]: version conflict, current version \[\d+\] is higher or equal to the one provided \[\d+\]$/
+        else
+          /^\[\d+\]: version conflict, current version \[\d+\] is higher or equal to the one provided \[\d+\]$/
+        end
       # rubocop:enable Metrics/LineLength
       error['type'] == 'version_conflict_engine_exception' &&
         error['reason'] =~ regexp

--- a/spec/zelastic/indexer_spec.rb
+++ b/spec/zelastic/indexer_spec.rb
@@ -3,11 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe Zelastic::Indexer do
+  let(:type) { Gem::Version.new(client.info.dig('version', 'number')) <= Gem::Version.new('7.0.0') }
   let(:config) do
     Zelastic::Config.new(
       client: client,
       data_source: data_source,
-      mapping: mapping
+      mapping: mapping,
+      type: type
     ) { |_| {} }
   end
 
@@ -32,6 +34,7 @@ RSpec.describe Zelastic::Indexer do
 
   def flush!
     client.indices.flush(index: config.read_alias)
+    client.indices.refresh(index: config.read_alias)
   end
 
   def get_all

--- a/zelastic.gemspec
+++ b/zelastic.gemspec
@@ -1,7 +1,6 @@
-
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'zelastic/version'
 


### PR DESCRIPTION
Elasticsearch 7.6 removes types, this allows for the gem to support both
versions via a `type` flag.