### PR TITLE
Support Elasticsearch v8 (and v7) & lazy data source eval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
       - image: "elasticsearch:<< parameters.elasticsearch_version >>"
         environment:
           "discovery.type": single-node
+          "xpack.security.enabled": false
     environment:
       ELASTICSEARCH_GEM_VERSION: "<< parameters.elasticsearch_gem_version >>"
     steps:
@@ -28,6 +29,15 @@ workflows:
   test:
     jobs:
       - test:
+          name: "test with elasticsearch v8
+            and gem << matrix.elasticsearch_gem_version >>
+            and ruby v<< matrix.ruby_version >>"
+          elasticsearch_version: "8.3.3"
+          matrix:
+            parameters:
+              ruby_version: ["3.1", "2.7"]
+              elasticsearch_gem_version: ["~> 8", "~> 7"]
+      - test:
           name: "test with elasticsearch v7
             and gem << matrix.elasticsearch_gem_version >>
             and ruby v<< matrix.ruby_version >>"
@@ -35,13 +45,4 @@ workflows:
           matrix:
             parameters:
               ruby_version: ["3.1", "2.7"]
-              elasticsearch_gem_version: ["~> 7", "~> 5"]
-      - test:
-          name: "test with elasticsearch v5
-            and gem ~> 5
-            and ruby v<< matrix.ruby_version >>"
-          elasticsearch_version: "5.6-alpine"
-          elasticsearch_gem_version: "~> 5"
-          matrix:
-            parameters:
-              ruby_version: ["3.1", "2.7"]
+              elasticsearch_gem_version: ["~> 7"]

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/log/*.log
 /Gemfile.lock
 
 # rspec failure tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,44 @@
-v0.5.1 - Aug 8th, 2018
----
+# Changelog
 
-- Fix re-indexing log output upon initial index creation (#7)
+All notable changes to this project will be documented in this file.
 
-v0.5.0 - Aug 3rd, 2018
----
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-- An _ESTIMATED_ % completion of ES re-indexing is logged, as the new index gets populated (#5)
+## How do I make a good changelog?
 
+### Guiding Principles
 
-v0.4.0 - May 29th, 2018
----
+- Changelogs are for humans, not machines.
+- There should be an entry for every single version.
+- The same types of changes should be grouped.
+- Versions and sections should be linkable.
+- The latest version comes first.
+- The release date of each version is displayed.
+- Keep an `Unreleased` section at the top to track upcoming changes.
 
-- Warning rather than exception on ignorable version conflicts (#4)
+### Types of changes
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+## [Unreleased]
+
+## Unreleased: [1.0.0] - 2022-08-XX
+### Added
+- Support for Ruby 3 (and keep support for 2.7).
+- Support for Elasticsearch v8 (and keep support for v7).
+- Support setting a logger in `Config`.
+- Support refresh on `IndexManager#populate_index`.
+- Support Proc in `Config#data_source` so it can be lazily evaluated.
+
+### Removed
+- Drop support for Ruby 2.6.
+- Drop support for Elasticsearch v5 and v6.
+
+[Unreleased]: https://github.com/carwow/zelastic/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/carwow/zelastic/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# Zero-downtime indexing from ActiveRecord->Elasticsearch
+# Zelastic
+
+Zero-downtime Elasticsearch tooling for managing indices and indexing from
+ActiveRecord with PostgreSQL to Elasticsearch.
 
 ## Installation
 
@@ -10,13 +13,14 @@ gem 'zelastic'
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 
     $ gem install zelastic
 
 ## Usage
+
 ### Setup
 
 For each ActiveRecord scope you want to index, you'll need a configuration:
@@ -46,7 +50,6 @@ You can also override some defaults, if you wish:
   here
 - `read_alias`: by default this is the table name of the `data_source`
 - `write_alias`: by default this is the `read_alias`, with `_write` appended
-- `type`: by default this is `read_alias.singularize`
 
 If you pass an array to as the `client` argument, all writes will be applied to every client in the
 array.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+
+require 'active_record'
 require 'active_support'
 require 'active_support/core_ext'
 require 'elasticsearch'
 require 'ostruct'
+require 'pry'
 require 'securerandom'
+
 require 'zelastic'
 
 RSpec.configure do |config|

--- a/zelastic.gemspec
+++ b/zelastic.gemspec
@@ -24,12 +24,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'elasticsearch', '>= 7', '< 9'
+
+  spec.add_dependency 'activerecord'
   spec.add_dependency 'activesupport'
 
-  spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'carwow_rubocop', '~> 4'
-  spec.add_development_dependency 'elasticsearch', '>= 5', '< 8'
   spec.add_development_dependency 'pry', '~> 0.14'
   spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
We are still on v0 so going for a breaking change since we no longer care
about Elasticsearch < v7 and Ruby < 2.7.

But also working towards a v1 release since the gem has been somewhat
neglected, by doing some extra changes to remove hacks in other
services, e.g. deals service.

Added
- Support for Ruby 3 (and keep support for 2.7).
- Support for Elasticsearch v8 (and keep support for v7).
- Support setting a logger in `Config`.
- Support refresh on `IndexManager#populate_index`.
- Support Proc in `Config#data_source` so it can be lazily evaluated.

Removed
- Drop support for Ruby 2.6. (Previous PR.)
- Drop support for Elasticsearch v5 and v6.

The README has also been updated to reflect that the gem only supports
Elasticsearch and ActiveRecord with PG since we rely on txid which is PG
specific and we don't have a way around it.

TODO (maybe, on a separate PR):
 - Avoid calling `index_data` multiple times when double writing.