### PR TITLE
[DVD-111818] Add op_type and conflicts kwargs to reindex_from_local / reindex_from_remote

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elasticsearch: ["8.3.3"]
+        elasticsearch: ["8.19.15"]
         elasticsearch_gem: ["~> 8", "~> 7"]
         include:
-          - elasticsearch: "7.17.5"
+          - elasticsearch: "7.17.28"
             elasticsearch_gem: "~> 7"
 
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased] - XXXX-XX-XX
 
+## [0.9.1]
+### Added
+- `op_type` and `conflicts` kwargs on `IndexManager#reindex_from_local` and `#reindex_from_remote`. Defaults to `nil`, 
+  which omits them from the request body and preserves Elasticsearch defaults. Pass `op_type: 'create'` and
+  `conflicts: 'proceed'` for safe concurrent backfills - this avoids overwriting fresher live writes at the destination, and 
+  logs conflicts instead of aborting.
+
 ## [0.8.0] - 2022-08-19
 ### Added
 - Support for Ruby 3 (and keep support for 2.7).

--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -19,9 +19,9 @@ module Zelastic
     def populate_index(unique_name = nil, batch_size: 3000, refresh: false)
       index_name = index_name_from_unique(unique_name)
 
-      config.data_source.find_in_batches(batch_size: batch_size).with_index do |batch, i|
-        logger.info(populate_index_log(batch_size: batch_size, batch_number: i + 1))
-        indexer.index_batch(batch, client: client, index_name: index_name, refresh: refresh)
+      config.data_source.find_in_batches(batch_size:).with_index do |batch, i|
+        logger.info(populate_index_log(batch_size:, batch_number: i + 1))
+        indexer.index_batch(batch, client:, index_name:, refresh:)
       end
     end
 
@@ -64,9 +64,9 @@ module Zelastic
                  )
 
       actions = other_write_indices.map do |index|
-        { remove: { index: index, alias: config.write_alias } }
+        { remove: { index:, alias: config.write_alias } }
       end
-      client.indices.update_aliases(body: { actions: actions })
+      client.indices.update_aliases(body: { actions: })
     end
 
     def cleanup_old_indices
@@ -95,23 +95,23 @@ module Zelastic
     def reindex_from_local(source_index:, dest_index:, wait_for_completion: false, op_type: nil, conflicts: nil)
       logger.info("Reindexing from #{source_index} to #{dest_index}")
       reindex(
-        source: { index: source_index }, dest_index: dest_index,
-        wait_for_completion: wait_for_completion,
-        op_type: op_type, 
-        conflicts: conflicts
+        source: { index: source_index }, dest_index:,
+        wait_for_completion:,
+        op_type:,
+        conflicts:
       )
     end
 
     def reindex_from_remote(
-        source_host:, 
-        source_index:, 
-        dest_index:,
-        username: nil, 
-        password: nil, 
-        wait_for_completion: false,
-        op_type: nil, 
-        conflicts: nil
-      )
+      source_host:,
+      source_index:,
+      dest_index:,
+      username: nil,
+      password: nil,
+      wait_for_completion: false,
+      op_type: nil,
+      conflicts: nil
+    )
       logger.info("Reindexing from remote #{source_host}/#{source_index} to #{dest_index}")
 
       remote = { host: source_host }
@@ -119,11 +119,11 @@ module Zelastic
       remote[:password] = password if password
 
       reindex(
-        source: { remote: remote, index: source_index }, 
-        dest_index: dest_index,
-        wait_for_completion: wait_for_completion,
-        op_type: op_type, 
-        conflicts: conflicts
+        source: { remote:, index: source_index },
+        dest_index:,
+        wait_for_completion:,
+        op_type:,
+        conflicts:
       )
     end
 
@@ -145,10 +145,10 @@ module Zelastic
       dest = { index: dest_index }
       dest[:op_type] = op_type if op_type
 
-      body = { source: source, dest: dest }
+      body = { source:, dest: }
       body[:conflicts] = conflicts if conflicts
 
-      client.reindex(body: body, wait_for_completion: wait_for_completion)
+      client.reindex(body:, wait_for_completion:)
     end
 
     def indexer

--- a/lib/zelastic/index_manager.rb
+++ b/lib/zelastic/index_manager.rb
@@ -92,23 +92,38 @@ module Zelastic
       client.indices.delete(index: indices_to_delete)
     end
 
-    def reindex_from_local(source_index:, dest_index:, wait_for_completion: false)
+    def reindex_from_local(source_index:, dest_index:, wait_for_completion: false, op_type: nil, conflicts: nil)
       logger.info("Reindexing from #{source_index} to #{dest_index}")
-      reindex(source: { index: source_index }, dest_index: dest_index,
-        wait_for_completion: wait_for_completion
+      reindex(
+        source: { index: source_index }, dest_index: dest_index,
+        wait_for_completion: wait_for_completion,
+        op_type: op_type, 
+        conflicts: conflicts
       )
     end
 
-    def reindex_from_remote(source_host:, source_index:, dest_index:,
-      username: nil, password: nil, wait_for_completion: false)
+    def reindex_from_remote(
+        source_host:, 
+        source_index:, 
+        dest_index:,
+        username: nil, 
+        password: nil, 
+        wait_for_completion: false,
+        op_type: nil, 
+        conflicts: nil
+      )
       logger.info("Reindexing from remote #{source_host}/#{source_index} to #{dest_index}")
 
       remote = { host: source_host }
       remote[:username] = username if username
       remote[:password] = password if password
 
-      reindex(source: { remote: remote, index: source_index }, dest_index: dest_index,
-        wait_for_completion: wait_for_completion
+      reindex(
+        source: { remote: remote, index: source_index }, 
+        dest_index: dest_index,
+        wait_for_completion: wait_for_completion,
+        op_type: op_type, 
+        conflicts: conflicts
       )
     end
 
@@ -126,14 +141,14 @@ module Zelastic
 
     def_delegators :config, :logger
 
-    def reindex(source:, dest_index:, wait_for_completion:)
-      client.reindex(
-        body: {
-          source: source,
-          dest: { index: dest_index }
-        },
-        wait_for_completion: wait_for_completion
-      )
+    def reindex(source:, dest_index:, wait_for_completion:, op_type: nil, conflicts: nil)
+      dest = { index: dest_index }
+      dest[:op_type] = op_type if op_type
+
+      body = { source: source, dest: dest }
+      body[:conflicts] = conflicts if conflicts
+
+      client.reindex(body: body, wait_for_completion: wait_for_completion)
     end
 
     def indexer

--- a/lib/zelastic/indexer.rb
+++ b/lib/zelastic/indexer.rb
@@ -23,9 +23,9 @@ module Zelastic
 
     def index_batch(batch, client: nil, index_name: nil, refresh: false)
       version = current_version
-      execute_bulk(client: client, index_name: index_name, refresh: refresh) do |index|
+      execute_bulk(client:, index_name:, refresh:) do |index|
         batch.map do |record|
-          index_command(index: index, version: version, record: record)
+          index_command(index:, version:, record:)
         end
       end
     end
@@ -33,8 +33,8 @@ module Zelastic
     def index_record(record, refresh: false)
       version = current_version
 
-      execute_bulk(refresh: refresh) do |index_name|
-        [index_command(index: index_name, version: version, record: record)]
+      execute_bulk(refresh:) do |index_name|
+        [index_command(index: index_name, version:, record:)]
       end
     end
 
@@ -56,7 +56,7 @@ module Zelastic
       logger.info('ES: Deleting batch records')
 
       config.clients.map do |client|
-        client.delete_by_query(index: config.write_alias, body: { query: query })
+        client.delete_by_query(index: config.write_alias, body: { query: })
       end
     end
 
@@ -82,7 +82,7 @@ module Zelastic
           _index: index,
           _id: record.id,
           data: config.index_data(record),
-          version: version,
+          version:,
           version_type: :external
         }
       }
@@ -96,7 +96,7 @@ module Zelastic
 
         commands = indices.flat_map(&block)
 
-        current_client.bulk(body: commands, refresh: refresh).tap do |result|
+        current_client.bulk(body: commands, refresh:).tap do |result|
           check_errors!(result)
         end
       end

--- a/lib/zelastic/version.rb
+++ b/lib/zelastic/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Zelastic
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end

--- a/spec/zelastic/index_manager_spec.rb
+++ b/spec/zelastic/index_manager_spec.rb
@@ -105,27 +105,29 @@ RSpec.describe Zelastic::IndexManager do
     end
 
     context 'with op_type: "create" and conflicts: "proceed"' do
-      it 'does not overwrite existing destination documents and does not abort on conflicts' do
-        source_index = "#{config.read_alias}_#{source_index_id}"
-        dest_index = "#{config.read_alias}_#{dest_index_id}"
+      let(:source_index) { "#{config.read_alias}_#{source_index_id}" }
+      let(:dest_index) { "#{config.read_alias}_#{dest_index_id}" }
 
+      let(:response) do
         client.index(index: dest_index, id: 1, body: { marker: 'pre-existing' }, refresh: true)
 
-        response = index_manager.reindex_from_local(
+        index_manager.reindex_from_local(
           source_index:,
           dest_index:,
           wait_for_completion: true,
           op_type: 'create',
           conflicts: 'proceed'
-        )
+        ).tap { client.indices.refresh(index: dest_index) }
+      end
 
+      it 'reports version conflicts in the response instead of aborting' do
         expect(response['version_conflicts']).to be >= 1
+      end
 
-        client.indices.refresh(index: dest_index)
+      it 'does not overwrite pre-existing destination documents' do
+        response
         existing = client.get(index: dest_index, id: 1)
         expect(existing['_source']).to eq('marker' => 'pre-existing')
-
-        expect(client.count(index: dest_index)['count']).to eq(3)
       end
     end
   end

--- a/spec/zelastic/index_manager_spec.rb
+++ b/spec/zelastic/index_manager_spec.rb
@@ -103,5 +103,30 @@ RSpec.describe Zelastic::IndexManager do
 
       expect(result['count']).to eq(3)
     end
+
+    context 'with op_type: "create" and conflicts: "proceed"' do
+      it 'does not overwrite existing destination documents and does not abort on conflicts' do
+        source_index = "#{config.read_alias}_#{source_index_id}"
+        dest_index = "#{config.read_alias}_#{dest_index_id}"
+
+        client.index(index: dest_index, id: 1, body: { marker: 'pre-existing' }, refresh: true)
+
+        response = index_manager.reindex_from_local(
+          source_index: source_index,
+          dest_index: dest_index,
+          wait_for_completion: true,
+          op_type: 'create',
+          conflicts: 'proceed'
+        )
+
+        expect(response['version_conflicts']).to be >= 1
+
+        client.indices.refresh(index: dest_index)
+        existing = client.get(index: dest_index, id: 1)
+        expect(existing['_source']).to eq('marker' => 'pre-existing')
+
+        expect(client.count(index: dest_index)['count']).to eq(3)
+      end
+    end
   end
 end

--- a/spec/zelastic/index_manager_spec.rb
+++ b/spec/zelastic/index_manager_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 RSpec.describe Zelastic::IndexManager do
   let(:config) do
     Zelastic::Config.new(
-      client: client,
-      data_source: data_source,
-      mapping: mapping,
+      client:,
+      data_source:,
+      mapping:,
       logger: Logger.new('log/test.log')
     ) { |_| {} }
   end
@@ -84,7 +84,7 @@ RSpec.describe Zelastic::IndexManager do
       source_index = "#{config.read_alias}_#{source_index_id}"
       dest_index = "#{config.read_alias}_#{dest_index_id}"
 
-      index_manager.reindex_from_local(source_index: source_index, dest_index: dest_index, wait_for_completion: true)
+      index_manager.reindex_from_local(source_index:, dest_index:, wait_for_completion: true)
 
       client.indices.refresh(index: dest_index)
       result = client.count(index: dest_index)
@@ -96,7 +96,7 @@ RSpec.describe Zelastic::IndexManager do
       source_index = "#{config.read_alias}_#{source_index_id}"
       dest_index = "#{config.read_alias}_#{dest_index_id}"
 
-      index_manager.reindex_from_local(source_index: source_index, dest_index: dest_index, wait_for_completion: true)
+      index_manager.reindex_from_local(source_index:, dest_index:, wait_for_completion: true)
 
       client.indices.refresh(index: dest_index)
       result = client.count(index: dest_index)
@@ -112,8 +112,8 @@ RSpec.describe Zelastic::IndexManager do
         client.index(index: dest_index, id: 1, body: { marker: 'pre-existing' }, refresh: true)
 
         response = index_manager.reindex_from_local(
-          source_index: source_index,
-          dest_index: dest_index,
+          source_index:,
+          dest_index:,
           wait_for_completion: true,
           op_type: 'create',
           conflicts: 'proceed'

--- a/spec/zelastic/indexer_spec.rb
+++ b/spec/zelastic/indexer_spec.rb
@@ -5,9 +5,9 @@ require 'spec_helper'
 RSpec.describe Zelastic::Indexer do
   let(:config) do
     Zelastic::Config.new(
-      client: client,
-      data_source: data_source,
-      mapping: mapping,
+      client:,
+      data_source:,
+      mapping:,
       logger: Logger.new('log/test.log')
     ) { |_| {} }
   end


### PR DESCRIPTION
[Kanban Card](https://carwow.kanbanize.com/ctrl_board/108/cards/111818/details/)

The `reindex_from_local` / `reindex_from_remote` methods added in #79 hard-coded the request body to Elasticsearch's defaults: `op_type: 'index'` (overwrite) and `conflicts: 'abort'`. 

We want to use different values for these (`op_type: 'create'` and `conflicts: 'proceed'`), so adding optional kwargs to allow for this. Both kwargs default to `nil` and are omitted from the request body when nil, so existing callers see no behaviour change.
